### PR TITLE
Bl4 support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,33 @@
+name: Publish to Docker Hub
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/myimage:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/myimage:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 
-ENV SHIFT_GAMES='bl3 blps bl2 bl1' \
+ENV SHIFT_GAMES='bl4 bl3 blps bl2 bl1' \
     SHIFT_PLATFORMS='epic steam' \
     SHIFT_ARGS='--schedule' \
     TZ='America/Chicago'

--- a/Readme.md
+++ b/Readme.md
@@ -2,11 +2,11 @@
 
 - **Compatibility:** 3.9+.
 - **Platform:** Crossplatform.
-- **Repo:** https://github.com/ugoogalizer/autoshift forked from https://github.com/Fabbi/autoshift
+- **Repo:** https://github.com/zarmstrong/autoshift forked from https://github.com/ugoogalizer/autoshift forked from https://github.com/Fabbi/autoshift
 
 # Overview
 
-Data provided by Mental Mars' Websites via this [shiftcodes.json](https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json) file that is updated reguarly by an instance of [this scraper](https://github.com/ugoogalizer/autoshift-scraper).  You don't need to run the scraper as well, only this `autoshift` script/container.  This is to reduce the burden on the Mental Mars website given the great work they're doing to make this possible.<br>
+Data provided by Mental Mars' Websites via this [shiftcodes.json](https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json) file that is updated reguarly by an instance of [this scraper](https://github.com/zarmstrong/autoshift-scraper).  You don't need to run the scraper as well, only this `autoshift` script/container.  This is to reduce the burden on the Mental Mars website given the great work they're doing to make this possible.<br>
 
 This documentation intended to be temporary until Issue [#53](https://github.com/Fabbi/autoshift/issues/53) and PR [#54](https://github.com/Fabbi/autoshift/pull/54) in the the upstream [autoshift by Fabbi](https://github.com/Fabbi/autoshift/) is merged in.
 
@@ -16,6 +16,7 @@ Games currently maintained by mental mars that are scraped and made available to
 - [Borderlands](https://mentalmars.com/game-news/borderlands-golden-keys/)
 - [Borderlands 2](https://mentalmars.com/game-news/borderlands-2-golden-keys/)
 - [Borderlands 3](https://mentalmars.com/game-news/borderlands-3-golden-keys/)
+- [Borderlands 4](https://mentalmars.com/game-news/borderlands-4-shift-codes/)
 - [Borderlands The Pre-Sequel](https://mentalmars.com/game-news/bltps-golden-keys/)
 - [Tiny Tina's Wonderlands](https://mentalmars.com/game-news/tiny-tinas-wonderlands-shift-codes)
 
@@ -31,7 +32,7 @@ You can choose to only redeem mods/skins etc, only golden keys or both. There is
 ## Installation
 
 ```sh
-git clone git@github.com:ugoogalizer/autoshift.git
+git clone git@github.com:zarmstrong/autoshift.git
 ```
 
 or download it as zip
@@ -128,7 +129,7 @@ docker run \
   -e SHIFT_ARGS='--schedule -v' \
   -e TZ='America/Chicago' \
   -v autoshift:/autoshift/data \
-  ugoogalizer/autoshift:latest
+  zarmstrong/autoshift:latest
 ```
 
 ## Docker Compose Usage:
@@ -138,7 +139,7 @@ docker run \
 version: "3.0"
 services:
   autoshift:
-    image: ugoogalizer/autoshift:latest
+    image: zarmstrong/autoshift:latest
     container_name: autoshift_all
     restart: always
     volumes:
@@ -186,9 +187,7 @@ spec:
     spec:
       containers:
         - name: autoshift
-          # Fix version so it doesn't auto-update
-          #image: fabianschweinfurth/autoshift@sha256:4cc0232e371f574c992fa7df3290f3fd037f4c36e4cc00c79f8228634bb08550
-          image: ugoogalizer/autoshift/autoshift:1.8
+          image: zarmstrong/autoshift/autoshift:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: SHIFT_USER
@@ -352,10 +351,10 @@ docker push ${HARBORURL}:443/autoshift/autoshift:latest
 docker push ${HARBORURL}:443/autoshift/autoshift:${VERSIONTAG}
 
 #Tag and Push the image to public docker hub repo
-docker login -u ugoogalizer docker.io/ugoogalizer/autoshift
-docker tag ${IMAGE} docker.io/ugoogalizer/autoshift:latest
-docker tag ${IMAGE} docker.io/ugoogalizer/autoshift:${VERSIONTAG}
-docker push docker.io/ugoogalizer/autoshift:latest
-docker push docker.io/ugoogalizer/autoshift:${VERSIONTAG}
+docker login -u zarmstrong docker.io/zarmstrong/autoshift
+docker tag ${IMAGE} docker.io/zarmstrong/autoshift:latest
+docker tag ${IMAGE} docker.io/zarmstrong/autoshift:${VERSIONTAG}
+docker push docker.io/zarmstrong/autoshift:latest
+docker push docker.io/zarmstrong/autoshift:${VERSIONTAG}
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 # Overview
 
-Data provided by Mental Mars' Websites via this [shiftcodes.json](https://raw.githubusercontent.com/ugoogalizer/autoshift-codes/main/shiftcodes.json) file that is updated reguarly by an instance of [this scraper](https://github.com/ugoogalizer/autoshift-scraper).  You don't need to run the scraper as well, only this `autoshift` script/container.  This is to reduce the burden on the Mental Mars website given the great work they're doing to make this possible.<br>
+Data provided by Mental Mars' Websites via this [shiftcodes.json](https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json) file that is updated reguarly by an instance of [this scraper](https://github.com/ugoogalizer/autoshift-scraper).  You don't need to run the scraper as well, only this `autoshift` script/container.  This is to reduce the burden on the Mental Mars website given the great work they're doing to make this possible.<br>
 
 This documentation intended to be temporary until Issue [#53](https://github.com/Fabbi/autoshift/issues/53) and PR [#54](https://github.com/Fabbi/autoshift/pull/54) in the the upstream [autoshift by Fabbi](https://github.com/Fabbi/autoshift/) is merged in.
 

--- a/Readme.md
+++ b/Readme.md
@@ -123,7 +123,7 @@ docker run \
   --restart=always \
   -e SHIFT_USER='<username>' \
   -e SHIFT_PASS='<password>' \
-  -e SHIFT_GAMES='bl3 blps bl2 bl1 ttw' \
+  -e SHIFT_GAMES='bl4 bl3 blps bl2 bl1 ttw' \
   -e SHIFT_PLATFORMS='epic xboxlive psn nintendo' \
   -e SHIFT_ARGS='--schedule -v' \
   -e TZ='America/Chicago' \
@@ -148,7 +148,7 @@ services:
       - SHIFT_PLATFORMS=epic xboxlive psn
       - SHIFT_USER=<username>
       - SHIFT_PASS=<password>
-      - SHIFT_GAMES=bl3 blps bl2 bl1 ttw gdfll
+      - SHIFT_GAMES=bl4 bl3 blps bl2 bl1 ttw gdfll
       - SHIFT_ARGS=--schedule -v
 ```
 ## Kubernetes Usage:
@@ -206,7 +206,7 @@ spec:
             - name: SHIFT_ARGS
               value: "--schedule 6 -v"
             - name: SHIFT_GAMES
-              value: "bl3 blps bl2 bl1 ttw"
+              value: "bl4 bl3 blps bl2 bl1 ttw"
             - name: TZ
               value: "Australia/Sydney"
           resources:
@@ -258,7 +258,7 @@ Example: `p@ssw0rd`
 #### **SHIFT_GAMES** (recommended)
 The game(s) you want to redeem codes for
 
-Default: `bl3 blps bl2 bl`
+Default: `bl4 bl3 blps bl2 bl`
 
 Example: `blps` or `bl bl2 bl3`
 
@@ -268,6 +268,7 @@ Example: `blps` or `bl bl2 bl3`
 |Borderlands 2|`bl2`|
 |Borderlands: The Pre-Sequel|`blps`|
 |Borderlands 3|`bl3`|
+|Borderlands 4|`bl4`|
 |Tiny Tina's Wonderlands|`ttw`|
 |Godfall|`gdfll`|
 

--- a/query.py
+++ b/query.py
@@ -66,6 +66,7 @@ known_games = SymmetricDict({
     "bl1":  "Borderlands: Game of the Year Edition",
     "bl2":  "Borderlands 2",
     "bl3":  "Borderlands 3",
+    "bl4":  "Borderlands 4",
     "blps": "Borderlands: The Pre-Sequel",
     "ttw":  "Tiny Tina's Wonderland",
     "gdfll": "Godfall",

--- a/query.py
+++ b/query.py
@@ -361,7 +361,7 @@ def progn(*args: _VT) -> _VT:
 
 def parse_shift_orcicorn():
     import json
-    key_url = "https://raw.githubusercontent.com/ugoogalizer/autoshift-codes/main/shiftcodes.json"
+    key_url = "https://raw.githubusercontent.com/zarmstrong/autoshift-codes/main/shiftcodes.json"
 
 
     resp = requests.get(key_url)


### PR DESCRIPTION
This pull request adds support for "Borderlands 4" (`bl4`) to the project and updates documentation and code references to ensure consistency. The main changes include updating environment variables, documentation, and internal mappings to include `bl4`, as well as switching the source URL for the `shiftcodes.json` file to a new repository.

**Borderlands 4 support:**

* Added `bl4` to the default and example values for the `SHIFT_GAMES` environment variable in the `Dockerfile` and throughout the `Readme.md` documentation. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R3) [[2]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L126-R126) [[3]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L151-R151) [[4]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L209-R209) [[5]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L261-R261)
* Included `bl4` in the internal mapping of supported games in `query.py`.
* Updated the documentation table to list "Borderlands 4" and its code (`bl4`).

**Source URL updates:**

* Changed the `shiftcodes.json` source URL in both `Readme.md` and `query.py` to point to the new repository at `zarmstrong/autoshift-codes` instead of `ugoogalizer/autoshift-codes`. [[1]](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L9-R9) [[2]](diffhunk://#diff-244d706da9cb57fee01485314422752b7cb4198021e2cbd241be794420f15320L363-R364)